### PR TITLE
Fix(api): Apply robust typing to aiRoutes.ts handler

### DIFF
--- a/src/api/aiRoutes.ts
+++ b/src/api/aiRoutes.ts
@@ -1,4 +1,4 @@
-import { Router, Request, Response } from 'express';
+import { Router, Request, Response, NextFunction } from 'express';
 // Import the new helper function and its return type
 import { getAISelectorActiveState, AISelectorChoiceState } from '../strategies/implementations/aiSelectorStrategy';
 // import { StrategyManager } from '../strategies/strategyManager'; // StrategyManager is likely already imported - REMOVED
@@ -6,12 +6,13 @@ import logger from '../utils/logger'; // Corrected logger import
 
 const router = Router();
 
-router.get('/current-strategy/:symbol', (req: Request, res: Response) => {
+router.get('/current-strategy/:symbol', async (req: Request, res: Response, next: NextFunction): Promise<void> => {
   const { symbol } = req.params;
   const upperSymbol = symbol ? symbol.toUpperCase() : "";
 
   if (!upperSymbol) {
-    return res.status(400).json({ message: "Symbol parameter is required." });
+    res.status(400).json({ message: "Symbol parameter is required." });
+    return;
   }
 
   try {
@@ -21,26 +22,29 @@ router.get('/current-strategy/:symbol', (req: Request, res: Response) => {
       // chosenStrategyName is already provided by getAISelectorActiveState
       const message = `AI is currently using ${aiState.chosenStrategyName} (ID: ${aiState.chosenStrategyId})${aiState.parametersUsed ? ' with specified parameters' : ' with default parameters'} for ${upperSymbol}.`;
       
-      return res.status(200).json({
+      res.status(200).json({
         symbol: upperSymbol,
         chosenStrategyId: aiState.chosenStrategyId,
         chosenStrategyName: aiState.chosenStrategyName,
         chosenParameters: aiState.parametersUsed,
         message: message
       });
+      return;
     } else {
       // Use message from aiState if available (e.g., "No strategy choice has been made...")
-      return res.status(404).json({
+      res.status(404).json({
         symbol: upperSymbol,
         message: aiState.message || `AI choice not available for symbol ${upperSymbol}.`
       });
+      return;
     }
   } catch (error) {
     logger.error(`Error fetching AI choice for symbol ${upperSymbol}:`, error);
-    return res.status(500).json({
+    res.status(500).json({
         symbol: upperSymbol,
         message: "Internal server error while fetching AI strategy choice."
     });
+    return;
   }
 });
 


### PR DESCRIPTION
I resolved the TS2769 "No overload matches this call" error for the route handler in `src/api/aiRoutes.ts` by:
- Adding `NextFunction` to the Express import.
- Modifying the handler signature to be `async (req, res, next): Promise<void>`.
- Ensuring `return;` is called explicitly after `res.json()` statements.

This ensures the handler conforms to the expected signature for asynchronous Express route handlers with strict TypeScript typing, similar to fixes I applied in other API route files.

All backend TypeScript compilation errors should now be resolved.