### PR TITLE
Fix: Remove duplicate ZAxis import in TradesOnPriceChart.tsx

### DIFF
--- a/frontend/src/components/TradesOnPriceChart.tsx
+++ b/frontend/src/components/TradesOnPriceChart.tsx
@@ -12,7 +12,6 @@ import {
   ResponsiveContainer,
   ReferenceDot, // For individual markers if needed, but Scatter is better for series
   ZAxis, // Needed if scatter point sizes vary, not strictly needed here
-  ZAxis, // Needed if scatter point sizes vary, not strictly needed here
 } from 'recharts';
 import { HistoricalDataPoint } from '../../../src/services/dataService'; // Adjust path if needed
 import { Trade } from '../../../src/backtest'; // Adjust path if needed


### PR DESCRIPTION
This commit removes a duplicated ZAxis import from the recharts library in the TradesOnPriceChart.tsx component. This duplication was causing a 'Identifier 'ZAxis' has already been declared' error during pre-transformation by Vite.