### PR TITLE
Fix: Improve error logging robustness to prevent crashes

### DIFF
--- a/src/services/aiSuggestionService.ts
+++ b/src/services/aiSuggestionService.ts
@@ -1,4 +1,5 @@
 // src/services/aiSuggestionService.ts
+import { logSafeError } from '../utils/safeLogger';
 import { fetchHistoricalDataFromDB } from './dataService';
 import { getMostRecentClosePrice } from './dataService';
 import { aiSelectorStrategy, getAISelectorActiveState } // Direct import
@@ -63,7 +64,7 @@ export async function getCapitalAwareStrategySuggestion(
     }
     logger.info(`[AISuggestionService] Fetched ${historicalDataForAI.length} data points for AI evaluation of ${symbol}.`);
   } catch (e) {
-    logger.error(`[AISuggestionService] Error fetching historical data for AI suggestion for ${symbol}:`, e);
+    logSafeError(logger, `[AISuggestionService] Error fetching historical data for AI suggestion for ${symbol}`, e);
     return {
         suggestedStrategyId: null,
         suggestedStrategyName: null,
@@ -237,7 +238,7 @@ export async function getCapitalAwareStrategySuggestion(
       };
     }
   } catch (error) {
-    logger.error(`[AISuggestionService] Error during AI strategy selection or parameter adjustment for ${symbol}:`, error);
+    logSafeError(logger, `[AISuggestionService] Error during AI strategy selection or parameter adjustment for ${symbol}`, error);
     return {
         suggestedStrategyId: null,
         suggestedStrategyName: null,

--- a/src/services/dataService.ts
+++ b/src/services/dataService.ts
@@ -1,5 +1,6 @@
 import axios from 'axios';
 import logger from '../utils/logger';
+import { logSafeError } from '../utils/safeLogger';
 import yahooFinance from 'yahoo-finance2';
 import { insertData, getRecentData, getFallbackData, FinancialData, queryHistoricalData as queryHistoricalDataFromDB } from '../database';
 
@@ -413,7 +414,7 @@ export async function fetchHistoricalDataFromDB(
     logger.info(`Successfully processed ${historicalData.length} historical data points from DB for ${symbol}.`);
     return historicalData;
   } catch (error) {
-    logger.error(`Error processing historical data from DB for ${symbol}:`, { error, symbol, startDate, endDate });
+    logSafeError(logger, `Error processing historical data from DB for ${symbol}`, error, { symbol, startDate: startDate.toISOString(), endDate: endDate.toISOString(), source_api, interval });
     throw error; 
   }
 }

--- a/src/utils/safeLogger.ts
+++ b/src/utils/safeLogger.ts
@@ -1,0 +1,50 @@
+import winston from 'winston';
+import logger from './logger'; // Assuming logger is the configured winston instance
+
+// Helper to safely stringify an object, handling circular references and BigInts
+function safeStringify(obj: any): string {
+  try {
+    return JSON.stringify(obj, (key, value) => {
+      if (typeof value === 'bigint') {
+        return value.toString() + 'n'; // Convert BigInt to string
+      }
+      return value;
+    }, 2); // Indent for readability
+  } catch (e) {
+    // Fallback for complex objects that JSON.stringify still fails on (e.g., Proxy)
+    if (e instanceof Error) {
+        return `[Unserializable Object: ${e.message}]`;
+    }
+    return '[Unserializable Object]';
+  }
+}
+
+export function logSafeError(
+  loggerInstance: winston.Logger,
+  message: string,
+  error: any,
+  additionalContext?: Record<string, any>
+): void {
+  let logDetails: Record<string, any> = {
+    messagePrimary: message, // Rename to avoid conflict with winston's own 'message'
+  };
+
+  if (error instanceof Error) {
+    logDetails.errorMessage = error.message;
+    logDetails.errorStack = error.stack;
+    // Avoid logging the full error object if it's a standard Error,
+    // as stack and message are primary. Log specific props if needed.
+    // logDetails.errorObject = safeStringify(error); // Or only specific known properties
+  } else if (typeof error === 'object' && error !== null) {
+    logDetails.errorObject = safeStringify(error);
+  } else {
+    logDetails.errorValue = String(error); // Log as string if not an object/Error
+  }
+
+  if (additionalContext) {
+    logDetails.context = safeStringify(additionalContext);
+  }
+
+  // Use the loggerInstance passed to it, which should be the main app logger
+  loggerInstance.error(message, logDetails);
+}


### PR DESCRIPTION
Introduced a `logSafeError` utility to handle potentially complex or circular error objects during logging.

Applied this utility in `dataService.ts` and `aiSuggestionService.ts` to prevent the logging mechanism itself from causing unhandled exceptions, which could lead to 500 errors in API responses.

This change addresses a potential cause for the reported 500 error when obtaining strategy suggestions, where complex errors caught might have crashed the logger.