### PR TITLE
Fix: Resolve duplicate export of getAllUniqueSymbols in database module

### DIFF
--- a/src/database/index.ts
+++ b/src/database/index.ts
@@ -231,7 +231,7 @@ function queryHistoricalData(
 }
 
 // Function to get all unique symbols from financial_data
-export function getAllUniqueSymbols(): string[] {
+function getAllUniqueSymbols(): string[] {
   if (!db) {
     console.error('[DATABASE CRITICAL] getAllUniqueSymbols called but db instance is not available!');
     throw new Error('[DATABASE CRITICAL] db instance is not available in getAllUniqueSymbols.');


### PR DESCRIPTION
The function `getAllUniqueSymbols` in `src/database/index.ts` was exported twice: once at its definition and again in a grouped export statement at the end of the file. This caused TypeScript compilation errors (TS2323, TS2484).

This commit resolves the issue by removing the `export` keyword from the function definition, leaving only the single export in the grouped statement.